### PR TITLE
Fix cannot set UART baudrate to those value other than 115200 issue.

### DIFF
--- a/src/uart.rs
+++ b/src/uart.rs
@@ -34,9 +34,9 @@ impl Mode for Async {}
 
 /// Uart driver.
 pub struct Uart<'a, M: Mode> {
-    pub info: Info,
-    pub tx: UartTx<'a, M>,
-    pub rx: UartRx<'a, M>,
+    info: Info,
+    tx: UartTx<'a, M>,
+    rx: UartRx<'a, M>,
 }
 
 /// Uart TX driver.
@@ -1099,9 +1099,9 @@ impl embedded_io_async::Write for Uart<'_, Async> {
     }
 }
 
-pub struct Info {
-    pub regs: &'static crate::pac::usart0::RegisterBlock,
-    pub index: usize,
+struct Info {
+    regs: &'static crate::pac::usart0::RegisterBlock,
+    index: usize,
 }
 
 trait SealedInstance {

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -89,6 +89,7 @@ impl Default for Config {
             sync_mode_master_select: Syncmst::Slave,
             continuous_clock: Cc::ClockOnCharacter,
             loopback_mode: Loop::Normal,
+            source_clock_hz: 16_000_000,
         }
     }
 }
@@ -332,7 +333,7 @@ impl<'a, M: Mode> Uart<'a, M> {
             regs.cfg().modify(|_, w| w.ctsen().enabled());
         }
 
-        Self::set_baudrate_inner::<T>(config.baudrate)?;
+        Self::set_baudrate_inner::<T>(config.baudrate, config.source_clock_hz)?;
         Self::set_uart_config::<T>(config);
 
         Ok(())
@@ -345,9 +346,7 @@ impl<'a, M: Mode> Uart<'a, M> {
         16_000_000
     }
 
-    fn set_baudrate_inner<T: Instance>(baudrate: u32) -> Result<()> {
-        let source_clock_hz = Self::get_fc_freq();
-
+    fn set_baudrate_inner<T: Instance>(baudrate: u32, source_clock_hz: u32) -> Result<()> {
         if baudrate == 0 || source_clock_hz == 0 {
             return Err(Error::InvalidArgument);
         }

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -372,12 +372,11 @@ impl<'a, M: Mode> Uart<'a, M> {
             let (_, osr, brg) = (8..16).rev().fold(
                 (u32::MAX, u32::MAX, u32::MAX),
                 |(best_diff, best_osr, best_brg), osrval| {
-                    let brgval = (source_clock_hz / ((osrval + 1) * baudrate)) - 1;
-                    let diff;
-
-                    if brgval > 65535 {
+                    if source_clock_hz < ((osrval + 1) * baudrate) {
                         (best_diff, best_osr, best_brg)
                     } else {
+                        let brgval = (source_clock_hz / ((osrval + 1) * baudrate)) - 1;
+                        let diff;
                         // Calculate the baud rate based on the BRG value
                         let candidate = source_clock_hz / ((osrval + 1) * (brgval + 1));
 

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -76,6 +76,7 @@ pub struct Config {
     pub loopback_mode: Loop,
     /// Source clock in Hz
     pub source_clock_hz: u32,
+    /// Clock type
     pub clock: crate::flexcomm::Clock,
 }
 
@@ -312,8 +313,6 @@ impl<'a, M: Mode> Uart<'a, M> {
         cts: Option<PeripheralRef<'_, AnyPin>>,
         config: Config,
     ) -> Result<()> {
-        // TODO - clock integration
-        //let clock = crate::flexcomm::Clock::Ffro;
         T::enable(config.clock);
         T::into_usart();
 
@@ -341,13 +340,6 @@ impl<'a, M: Mode> Uart<'a, M> {
         Self::set_uart_config::<T>(config);
 
         Ok(())
-    }
-
-    fn get_fc_freq() -> u32 {
-        // Todo: Make it generic for any clock
-        // Since the FC clock is hardcoded to Sfro, this freq is returned.
-        // sfro : 16MHz, // ffro: 48MHz
-        16_000_000
     }
 
     fn set_baudrate_inner<T: Instance>(baudrate: u32, source_clock_hz: u32) -> Result<()> {

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -311,7 +311,7 @@ impl<'a, M: Mode> Uart<'a, M> {
         config: Config,
     ) -> Result<()> {
         // TODO - clock integration
-        let clock = crate::flexcomm::Clock::Sfro;
+        let clock = crate::flexcomm::Clock::Ffro;
         T::enable(clock);
         T::into_usart();
 

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -76,6 +76,7 @@ pub struct Config {
     pub loopback_mode: Loop,
     /// Source clock in Hz
     pub source_clock_hz: u32,
+    pub clock: crate::flexcomm::Clock,
 }
 
 impl Default for Config {
@@ -92,6 +93,7 @@ impl Default for Config {
             continuous_clock: Cc::ClockOnCharacter,
             loopback_mode: Loop::Normal,
             source_clock_hz: 16_000_000,
+            clock: crate::flexcomm::Clock::Sfro,
         }
     }
 }
@@ -311,8 +313,8 @@ impl<'a, M: Mode> Uart<'a, M> {
         config: Config,
     ) -> Result<()> {
         // TODO - clock integration
-        let clock = crate::flexcomm::Clock::Ffro;
-        T::enable(clock);
+        //let clock = crate::flexcomm::Clock::Ffro;
+        T::enable(config.clock);
         T::into_usart();
 
         let regs = T::info().regs;

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -34,9 +34,9 @@ impl Mode for Async {}
 
 /// Uart driver.
 pub struct Uart<'a, M: Mode> {
-    info: Info,
-    tx: UartTx<'a, M>,
-    rx: UartRx<'a, M>,
+    pub info: Info,
+    pub tx: UartTx<'a, M>,
+    pub rx: UartRx<'a, M>,
 }
 
 /// Uart TX driver.
@@ -1097,9 +1097,9 @@ impl embedded_io_async::Write for Uart<'_, Async> {
     }
 }
 
-struct Info {
-    regs: &'static crate::pac::usart0::RegisterBlock,
-    index: usize,
+pub struct Info {
+    pub regs: &'static crate::pac::usart0::RegisterBlock,
+    pub index: usize,
 }
 
 trait SealedInstance {

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -74,6 +74,8 @@ pub struct Config {
     pub continuous_clock: Cc,
     /// Normal/ loopback mode
     pub loopback_mode: Loop,
+    /// Source clock in Hz
+    pub source_clock_hz: u32,
 }
 
 impl Default for Config {


### PR DESCRIPTION
In current Uart code, it only accepts 115200. If we set it to 3000000 or 4000000, the whole system will crash.
We need 3 changes to fix it:
1. Open clock setting to have user to set different type, for example:  FFRO. Now it is hardcoded as SFRO.
2. Open source clock setting in Hz, in our PTL program, we need to set it as 48M, but it is hardcoded as 16M Hz.
3. There is a bug in current code to calculate brgval.
    let brgval = (source_clock_hz / ((osrval + 1) * baudrate)) - 1;
    if source_clock_hz is 48M and baudrate is 4M, osrval is 15, brgval is be -1, since the type is u32, it cannot be accept by rust, it will return error.
    Need to use compare the number instead of compare it with FFFF.

I tested it in my device by setting 4M baudrarte, it can work as expected.